### PR TITLE
Update GH Actions to use dockercomposerun for Sec Scan and Lint

### DIFF
--- a/.github/workflows/check_deployable.yml
+++ b/.github/workflows/check_deployable.yml
@@ -15,25 +15,37 @@ jobs:
 
   code-standards-rubocop:
     runs-on: ubuntu-latest
+    env:
+      DEVENV: devenv
+      APP_IMAGE: app-devenv
 
     steps:
       - uses: actions/checkout@v1
       - name: Docker version
         run: docker --version
 
-      - name: Build linted app code deploy
-        run: docker build --no-cache --target lint -t app-lint .
+      - name: Build app development environment
+        run: "docker build --no-cache --target ${DEVENV} -t ${APP_IMAGE} ."
+
+      - name: dockercomposerun rubocop on development environment
+        run: ./script/dockercomposerun bundle exec rake rubocop
 
   security-scan-bundler-audit:
     runs-on: ubuntu-latest
+    env:
+      DEVENV: devenv
+      APP_IMAGE: app-devenv
 
     steps:
       - uses: actions/checkout@v1
       - name: Docker version
         run: docker --version
 
-      - name: Build security-scanned app code for deploy
-        run: docker build --no-cache --target secscan -t app-secscan .
+      - name: Build app development environment
+        run: "docker build --no-cache --target ${DEVENV} -t ${APP_IMAGE} ."
+
+      - name: dockercomposerun bundle:audit on development environment
+        run: ./script/dockercomposerun bundle exec rake bundle:audit
 
   build-deploy:
     needs: [code-standards-rubocop, security-scan-bundler-audit]


### PR DESCRIPTION
# What
This modifies the deployment GitHub Action to use the Docker Compose Framework (with the devenv image) to run the linting and static security scans instead of the layers inside the `Dockerfile`.

# Why
This is part of the effort to remove these checks from the Dockerfile

# Change Impact Analysis and Testing

- [x] Ensure Checks are Correct and Pass
- [x] Inspect Checks Output
