### PR TITLE
Split Out Push to Main Actions and Output Git Info on Push

### DIFF
--- a/.github/workflows/check_deployable.yml
+++ b/.github/workflows/check_deployable.yml
@@ -1,8 +1,6 @@
 name: Check Deployable
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/check_development_environment.yml
+++ b/.github/workflows/check_development_environment.yml
@@ -1,8 +1,6 @@
 name: Check Development Environment
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/push_to_main.yml
+++ b/.github/workflows/push_to_main.yml
@@ -1,0 +1,22 @@
+name: Check Development Environment
+
+on:
+  push:
+    branches: [ main ]
+
+
+jobs:
+  git-log:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Git log
+        run: git log
+
+      - name: Git the branch
+        run: echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
+
+      - name: Git the last commit
+        run: echo "Last Commit: $(git rev-parse --short HEAD)"
+


### PR DESCRIPTION
# What
This change set splits out the Push to Main and creates a simple GH action for push for some exploratory testing.

# Why
Prep for moving to new CI flow

# Change Impact Analysis and Testing
The PR checks are tested but the new Push to main will only run when merged.
