### PR TITLE
Add Checkout in detect-PR-migrations before calling changed files

### DIFF
--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -31,6 +31,10 @@ jobs:
     name: Detect Rails migration changes in PR
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Look for changed files
         id: changed-db-files
         uses: tj-actions/changed-files@v44.4.0


### PR DESCRIPTION
# What
Adds the checkout action to the On Merge `detect-PR-migrations` job as this is required.

# Why
Resolve failure `Error: Unable to locate the git repository in the given path: /home/runner/work/gh-actions-test-bed/gh-actions-test-bed` in `detect-PR-migrations` per its suggestion.

# Change Impact Analysis and Testing
Checking the checks
