### PR TITLE
Continue Development Testing of Branch add-action-delete-docker-hub-repo and Correct The Vetted Repository Name

### DIFF
--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -127,7 +127,7 @@ jobs:
         [
           "${{ needs.merged-image-names.outputs.dev_repository }}",
           "${{ needs.merged-image-names.outputs.unvetted_repository }}",
-          "${{ needs.merged-image-names.outputs.unvetted_repository }}"
+          "${{ needs.merged-image-names.outputs.vetted_repository }}"
         ]
       # LEX: REMOVE REF
       ref: add-action-delete-docker-hub-repo


### PR DESCRIPTION
# What
This PR is again for the development and testing of brianjbayer/actions-image-cicd#21, specifically correcting the pattern for deleting the PR branch-based image repositories on merge.

